### PR TITLE
don't require pry in Annotation class

### DIFF
--- a/lib/ld4l/open_annotation_rdf/annotation.rb
+++ b/lib/ld4l/open_annotation_rdf/annotation.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module LD4L
   module OpenAnnotationRDF
     class Annotation < ActiveTriples::Resource


### PR DESCRIPTION
@elrayle   This was probably an oversight when you checked in the latest code (with "resume").  you have some binding.pry  lines commented out too (which is less of a problem)

I'm trying to use these models in my Rails app and it doesn't need to know about pry from inside a model ...
