### PR TITLE
Add casting restrictions; Let Annotation.resume receive same parameters as .new

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,43 @@ puts stb.dump :ttl
 <http://example.org/term/engineering> a <http://www.w3.org/ns/oa#SemanticTag> .
 ```
 
+*Resume annotation of unknown type.*
+```
+## Using RDF::URI
+# Create the annotations first using previous examples.
+a1 = LD4L::OpenAnnotationRDF::Annotation.resume(RDF::URI('http://localhost/c10'))
+# => #<LD4L::OpenAnnotationRDF::CommentAnnotation:0x3fdd8267adc8(default)>
+
+a2 = LD4L::OpenAnnotationRDF::Annotation.resume(RDF::URI('http://localhost/t10'))
+# => #<LD4L::OpenAnnotationRDF::TagAnnotation:0x3fdd826073f0(default)>
+
+a3 = LD4L::OpenAnnotationRDF::Annotation.resume(RDF::URI('http://localhost/st10'))
+# => #<LD4L::OpenAnnotationRDF::SemanticTagAnnotation:0x3fdd8259c7a8(default)>
+
+
+## Using string URI
+# Create the annotations first using previous examples.
+a1 = LD4L::OpenAnnotationRDF::Annotation.resume('http://localhost/c10')
+# => #<LD4L::OpenAnnotationRDF::CommentAnnotation:0x3fdd8267adc8(default)>
+
+a2 = LD4L::OpenAnnotationRDF::Annotation.resume('http://localhost/t10')
+# => #<LD4L::OpenAnnotationRDF::TagAnnotation:0x3fdd826073f0(default)>
+
+a3 = LD4L::OpenAnnotationRDF::Annotation.resume('http://localhost/st10')
+# => #<LD4L::OpenAnnotationRDF::SemanticTagAnnotation:0x3fdd8259c7a8(default)>
+
+
+## Using localname expanded using configured base_uri
+# Create the annotations first using previous examples.
+a1 = LD4L::OpenAnnotationRDF::Annotation.resume('c10')
+# => #<LD4L::OpenAnnotationRDF::CommentAnnotation:0x3fdd8267adc8(default)>
+
+a2 = LD4L::OpenAnnotationRDF::Annotation.resume('t10')
+# => #<LD4L::OpenAnnotationRDF::TagAnnotation:0x3fdd826073f0(default)>
+
+a3 = LD4L::OpenAnnotationRDF::Annotation.resume('st10')
+# => #<LD4L::OpenAnnotationRDF::SemanticTagAnnotation:0x3fdd8259c7a8(default)>
+```
 
 ### Configurations
 

--- a/lib/ld4l/open_annotation_rdf/annotation.rb
+++ b/lib/ld4l/open_annotation_rdf/annotation.rb
@@ -14,8 +14,8 @@ module LD4L
       property :hasTarget,   :predicate => RDFVocabularies::OA.hasTarget    # :type => URI
       property :hasBody,     :predicate => RDFVocabularies::OA.hasBody
       property :annotatedBy, :predicate => RDFVocabularies::OA.annotatedBy, :class_name => LD4L::FoafRDF::Person
-      property :annotatedAt, :predicate => RDFVocabularies::OA.annotatedAt  # :type => xsd:dateTime    # the time Annotation was created
-      property :motivatedBy, :predicate => RDFVocabularies::OA.motivatedBy  # comes from RDFVocabularies::OA ontology
+      property :annotatedAt, :predicate => RDFVocabularies::OA.annotatedAt, :cast => false   # :type => xsd:dateTime    # the time Annotation was created
+      property :motivatedBy, :predicate => RDFVocabularies::OA.motivatedBy, :cast => false   # comes from RDFVocabularies::OA ontology
 
       def self.resume(*args)
         return nil      unless args.kind_of?(Array) && args.size > 0 && args.first.kind_of?(RDF::URI)
@@ -25,11 +25,10 @@ module LD4L
 
         # get motivatedBy
         m = a.get_values(:motivatedBy)
-        return a    unless m.kind_of?(Array) && m.size > 0 && m.first.kind_of?(ActiveTriples::Resource)
+        return a    unless m.kind_of?(Array) && m.size > 0 && m.first.kind_of?(RDF::Vocabulary::Term)
 
         # motivatedBy is set
-        m_uri = m.first.rdf_subject
-
+        m_uri = m.first
         # currently only support commenting and tagging
         return LD4L::OpenAnnotationRDF::CommentAnnotation.new(rdf_subject) if m_uri == RDFVocabularies::OA.commenting
         return a                                                       unless m_uri == RDFVocabularies::OA.tagging

--- a/lib/ld4l/open_annotation_rdf/annotation.rb
+++ b/lib/ld4l/open_annotation_rdf/annotation.rb
@@ -17,11 +17,9 @@ module LD4L
       property :annotatedAt, :predicate => RDFVocabularies::OA.annotatedAt, :cast => false   # :type => xsd:dateTime    # the time Annotation was created
       property :motivatedBy, :predicate => RDFVocabularies::OA.motivatedBy, :cast => false   # comes from RDFVocabularies::OA ontology
 
-      def self.resume(*args)
-        return nil      unless args.kind_of?(Array) && args.size > 0 && args.first.kind_of?(RDF::URI)
-
-        rdf_subject = args.first
-        a = new(rdf_subject)
+      def self.resume(uri_or_str)
+        # Let ActiveTriples::Resource validate uri_or_str when creating new Annotation
+        a = new(uri_or_str)
 
         # get motivatedBy
         m = a.get_values(:motivatedBy)
@@ -30,17 +28,17 @@ module LD4L
         # motivatedBy is set
         m_uri = m.first
         # currently only support commenting and tagging
-        return LD4L::OpenAnnotationRDF::CommentAnnotation.new(rdf_subject) if m_uri == RDFVocabularies::OA.commenting
+        return LD4L::OpenAnnotationRDF::CommentAnnotation.new(uri_or_str) if m_uri == RDFVocabularies::OA.commenting
         return a                                                       unless m_uri == RDFVocabularies::OA.tagging
 
         # Tagging can be TagAnnotation or SemanticTagAnnotation.  Only way to tell is by checking type of body.
-        sta = LD4L::OpenAnnotationRDF::SemanticTagAnnotation.new(rdf_subject)
+        sta = LD4L::OpenAnnotationRDF::SemanticTagAnnotation.new(uri_or_str)
         stb = sta.getBody
-        return sta                                           if stb.type.include?(RDFVocabularies::OA.SemanticTag)
+        return sta                          if stb.type.include?(RDFVocabularies::OA.SemanticTag)
 
-        ta = LD4L::OpenAnnotationRDF::TagAnnotation.new(rdf_subject)
+        ta = LD4L::OpenAnnotationRDF::TagAnnotation.new(uri_or_str)
         tb = ta.getBody
-        return ta                                            if tb.type.include?(RDFVocabularies::OA.Tag)
+        return ta                           if tb.type.include?(RDFVocabularies::OA.Tag)
 
         # can't match to a known annotation type, so return as generic annotation
         return a

--- a/lib/ld4l/open_annotation_rdf/comment_body.rb
+++ b/lib/ld4l/open_annotation_rdf/comment_body.rb
@@ -9,8 +9,8 @@ module LD4L
                 :base_uri => LD4L::OpenAnnotationRDF.configuration.base_uri,
                 :repository => :default
 
-      property :content, :predicate => RDFVocabularies::CNT.chars  # :type => XSD.string
-      property :format,  :predicate => RDF::DC.format              # :type => XSD.string
+      property :content, :predicate => RDFVocabularies::CNT.chars,  :cast => true  # :type => XSD.string
+      property :format,  :predicate => RDF::DC.format,              :cast => true  # :type => XSD.string
 
       def initialize(*args)
         super(*args)

--- a/lib/ld4l/open_annotation_rdf/tag_body.rb
+++ b/lib/ld4l/open_annotation_rdf/tag_body.rb
@@ -9,7 +9,7 @@ module LD4L
                 :base_uri => LD4L::OpenAnnotationRDF.configuration.base_uri,
                 :repository => :default
 
-      property :tag,     :predicate => RDFVocabularies::CNT.chars  # :type => XSD.string
+      property :tag,     :predicate => RDFVocabularies::CNT.chars,   :cast => false  # :type => XSD.string
 
       ##
       # Get a list of annotations using the tag value.

--- a/lib/ld4l/open_annotation_rdf/version.rb
+++ b/lib/ld4l/open_annotation_rdf/version.rb
@@ -1,5 +1,5 @@
 module LD4L
   module OpenAnnotationRDF
-    VERSION = "0.0.7"
+    VERSION = "0.0.8"
   end
 end

--- a/spec/ld4l/open_annotation_rdf/annotation_spec.rb
+++ b/spec/ld4l/open_annotation_rdf/annotation_spec.rb
@@ -183,7 +183,7 @@ describe 'LD4L::OpenAnnotationRDF::Annotation' do
       ca.persist!
       expect(ca).to be_persisted
       uri = ca.rdf_subject
-      
+
       a = LD4L::OpenAnnotationRDF::Annotation.resume(uri)
       expect(a).to be_a_kind_of(LD4L::OpenAnnotationRDF::CommentAnnotation)
       expect(a.hasTarget.first.rdf_subject.to_s).to eq "http://example.org/bibref/br3"

--- a/spec/ld4l/open_annotation_rdf/annotation_spec.rb
+++ b/spec/ld4l/open_annotation_rdf/annotation_spec.rb
@@ -151,13 +151,13 @@ describe 'LD4L::OpenAnnotationRDF::Annotation' do
 
     it "should be settable" do
       subject.motivatedBy = RDFVocabularies::OA.describing
-      expect(subject.motivatedBy.first.rdf_subject).to eq RDFVocabularies::OA.describing
+      expect(subject.motivatedBy.first).to eq RDFVocabularies::OA.describing
     end
 
     it "should be changeable" do
       subject.motivatedBy = RDFVocabularies::OA.describing
       subject.motivatedBy = RDFVocabularies::OA.classifying
-      expect(subject.motivatedBy.first.rdf_subject).to eq RDFVocabularies::OA.classifying
+      expect(subject.motivatedBy.first).to eq RDFVocabularies::OA.classifying
     end
   end
 
@@ -183,13 +183,13 @@ describe 'LD4L::OpenAnnotationRDF::Annotation' do
       ca.persist!
       expect(ca).to be_persisted
       uri = ca.rdf_subject
-
+      
       a = LD4L::OpenAnnotationRDF::Annotation.resume(uri)
       expect(a).to be_a_kind_of(LD4L::OpenAnnotationRDF::CommentAnnotation)
       expect(a.hasTarget.first.rdf_subject.to_s).to eq "http://example.org/bibref/br3"
       expect(a.annotatedBy.first).to eq a_person
       expect(a.annotatedAt.first).to eq a_time
-      expect(a.motivatedBy.first.rdf_subject).to eq RDFVocabularies::OA.commenting
+      expect(a.motivatedBy.first).to eq RDFVocabularies::OA.commenting
 
       b = a.getBody
       expect(b).to be_a_kind_of(LD4L::OpenAnnotationRDF::CommentBody)
@@ -215,7 +215,7 @@ describe 'LD4L::OpenAnnotationRDF::Annotation' do
       expect(a.hasTarget.first.rdf_subject.to_s).to eq "http://example.org/bibref/br3"
       expect(a.annotatedBy.first).to eq a_person
       expect(a.annotatedAt.first).to eq a_time
-      expect(a.motivatedBy.first.rdf_subject).to eq RDFVocabularies::OA.tagging
+      expect(a.motivatedBy.first).to eq RDFVocabularies::OA.tagging
 
       b = a.getBody
       expect(b).to be_a_kind_of(LD4L::OpenAnnotationRDF::TagBody)
@@ -240,7 +240,7 @@ describe 'LD4L::OpenAnnotationRDF::Annotation' do
       expect(a.hasTarget.first.rdf_subject.to_s).to eq "http://example.org/bibref/br3"
       expect(a.annotatedBy.first).to eq a_person
       expect(a.annotatedAt.first).to eq a_time
-      expect(a.motivatedBy.first.rdf_subject).to eq RDFVocabularies::OA.tagging
+      expect(a.motivatedBy.first).to eq RDFVocabularies::OA.tagging
 
       b = a.getBody
       expect(b).to be_a_kind_of(LD4L::OpenAnnotationRDF::SemanticTagBody)
@@ -293,7 +293,7 @@ describe 'LD4L::OpenAnnotationRDF::Annotation' do
           end
 
           it "should reset the motivatedBy" do
-            expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting.to_s
+            expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting.to_s
           end
 
           it "should be persisted" do
@@ -325,7 +325,7 @@ describe 'LD4L::OpenAnnotationRDF::Annotation' do
 
         it "should delete from the repository" do
           subject.reload
-          expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting.to_s
+          expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting.to_s
           subject.motivatedBy = []
           expect(subject.motivatedBy).to eq []
           subject.persist!

--- a/spec/ld4l/open_annotation_rdf/comment_annotation_spec.rb
+++ b/spec/ld4l/open_annotation_rdf/comment_annotation_spec.rb
@@ -154,18 +154,18 @@ describe 'LD4L::OpenAnnotationRDF::CommentAnnotation' do
 
   describe 'motivatedBy' do
     it "should be OA.commenting if we haven't set it" do
-      expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting
+      expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting
     end
 
     it "should be settable" do
       subject.motivatedBy = RDFVocabularies::OA.describing
-      expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.describing
+      expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.describing
     end
 
     it "should be changeable" do
       subject.motivatedBy = RDFVocabularies::OA.describing
       subject.motivatedBy = RDFVocabularies::OA.classifying
-      expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.classifying
+      expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.classifying
     end
   end
 
@@ -220,7 +220,7 @@ describe 'LD4L::OpenAnnotationRDF::CommentAnnotation' do
           end
 
           it "should reset the motivatedBy" do
-            expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting.to_s
+            expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting.to_s
           end
 
           it "should be persisted" do
@@ -252,7 +252,7 @@ describe 'LD4L::OpenAnnotationRDF::CommentAnnotation' do
 
         it "should delete from the repository" do
           subject.reload
-          expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting.to_s
+          expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting.to_s
           subject.motivatedBy = []
           expect(subject.motivatedBy).to eq []
           subject.persist!

--- a/spec/ld4l/open_annotation_rdf/semantic_tag_annotation_spec.rb
+++ b/spec/ld4l/open_annotation_rdf/semantic_tag_annotation_spec.rb
@@ -212,18 +212,18 @@ describe 'LD4L::OpenAnnotationRDF::SemanticTagAnnotation' do
 
   describe 'motivatedBy' do
     it "should be OA.tagging if we haven't set it" do
-      expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.tagging
+      expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.tagging
     end
 
     it "should be settable" do
       subject.motivatedBy = RDFVocabularies::OA.describing
-      expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.describing
+      expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.describing
     end
 
     it "should be changeable" do
       subject.motivatedBy = RDFVocabularies::OA.describing
       subject.motivatedBy = RDFVocabularies::OA.classifying
-      expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.classifying
+      expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.classifying
     end
   end
 
@@ -278,7 +278,7 @@ describe 'LD4L::OpenAnnotationRDF::SemanticTagAnnotation' do
           end
 
           it "should reset the motivatedBy" do
-            expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting.to_s
+            expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting.to_s
           end
 
           it "should be persisted" do
@@ -310,7 +310,7 @@ describe 'LD4L::OpenAnnotationRDF::SemanticTagAnnotation' do
 
         it "should delete from the repository" do
           subject.reload
-          expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting.to_s
+          expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting.to_s
           subject.motivatedBy = []
           expect(subject.motivatedBy).to eq []
           subject.persist!

--- a/spec/ld4l/open_annotation_rdf/tag_annotation_spec.rb
+++ b/spec/ld4l/open_annotation_rdf/tag_annotation_spec.rb
@@ -264,18 +264,18 @@ describe 'LD4L::OpenAnnotationRDF::TagAnnotation' do
 
   describe 'motivatedBy' do
     it "should be OA.tagging if we haven't set it" do
-      expect(subject.motivatedBy.first.rdf_subject).to eq RDFVocabularies::OA.tagging
+      expect(subject.motivatedBy.first).to eq RDFVocabularies::OA.tagging
     end
 
     it "should be settable" do
       subject.motivatedBy = RDFVocabularies::OA.describing
-      expect(subject.motivatedBy.first.rdf_subject).to eq RDFVocabularies::OA.describing
+      expect(subject.motivatedBy.first).to eq RDFVocabularies::OA.describing
     end
 
     it "should be changeable" do
       subject.motivatedBy = RDFVocabularies::OA.describing
       subject.motivatedBy = RDFVocabularies::OA.classifying
-      expect(subject.motivatedBy.first.rdf_subject).to eq RDFVocabularies::OA.classifying
+      expect(subject.motivatedBy.first).to eq RDFVocabularies::OA.classifying
     end
   end
 
@@ -330,7 +330,7 @@ describe 'LD4L::OpenAnnotationRDF::TagAnnotation' do
           end
 
           it "should reset the motivatedBy" do
-            expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting.to_s
+            expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting.to_s
           end
 
           it "should be persisted" do
@@ -362,7 +362,7 @@ describe 'LD4L::OpenAnnotationRDF::TagAnnotation' do
 
         it "should delete from the repository" do
           subject.reload
-          expect(subject.motivatedBy.first.rdf_subject.to_s).to eq RDFVocabularies::OA.commenting.to_s
+          expect(subject.motivatedBy.first.to_s).to eq RDFVocabularies::OA.commenting.to_s
           subject.motivatedBy = []
           expect(subject.motivatedBy).to eq []
           subject.persist!


### PR DESCRIPTION
## Change Log

### Add casting restriction
Impact:  This update requires changes to your code for all properties that now have :cast = false.

Affected properties:
* motivatedBy
* annotatedAt
* content
* format

Required change in your code for motivatedBy:
Assumptions: 
* anno is an instance of Annotation or a subclass

```
OLD:  anno.motivatedBy.first.rdf_subject
NEW:  anno.motivatedBy.first 
```

### Allow Annotation.resume to receive same argument values as Annotation.new

Annotation.resume now accepts the following values for its parameter.
* RDF::URI - e.g. RDF::URI('http://example.org/t123') -- this is the only value accepted prior to this change
* string URI - e.g. 'http://example.org/t123'
* localname - e.g. 't123' -- This will be expanded by appending 't123' to the end of the configured base_uri